### PR TITLE
パスワードリセット機能(開発環境) #18 (本番環境) #19

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -423,7 +423,7 @@ Rails.application.config.sorcery.configure do |config|
     # Hammering protection: how long in seconds to wait before allowing another email to be sent.
     # Default: `5 * 60`
     #
-    user.reset_password_time_between_emails = 1 * 1
+    user.reset_password_time_between_emails = 5 * 60
 
     # Access counter to a reset password page attribute name
     # Default: `:access_count_to_reset_password_page`


### PR DESCRIPTION
本番環境でのパスワードリセットが上手くいったので、
config/initializers/sorcery.rbのメール送信の間隔の設定をデフォルト値に戻しておく。