### PR TITLE
manifest.jsonの設定を変更 #152

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,14 +10,12 @@
     {
       "src": "/logo.png",
       "type": "image/png",
-      "sizes": "192x192",
-      "purpose": "maskable"
+      "sizes": "192x192"
     },
     {
       "src": "/logo.png",
       "type": "image/png",
-      "sizes": "512x512",
-      "purpose": "maskable"
+      "sizes": "512x512"
     }
   ]
 }


### PR DESCRIPTION
アドレスバーにインストールマークが出ないため、設定を修正した。
    
**やった事**
・`"purpose": "maskable" `の表記を削除
   
**理由：**
①以下の可能性があった事。
`"purpose": "maskable"`は、アイコンがマスクされることを示すためのプロパティ。
・このプロパティを使うと、ブラウザがアイコンを特定の形式に適応させることがある。
　しかし、アイコンがマスク可能な形式になっていない場合、問題が発生することがある。
デベロッパーツールのアプリケーションタブを確認しても、以下のように出ていたので可能性が高そう。
![image](https://github.com/user-attachments/assets/c998116f-b389-43e6-a1e9-9dfe1ccf8a07)

    
②https://www.gaji.jp/blog/2023/06/20/16156/によると、PWAのApp Iconは、複数のサイズのPNG画像を用意する必要がある。（→おそらく、manifect.js で設定したサイズと一致する画像の書き出しをして、複数publicは以下に配置しないといけないという事）しかし、自分は1つしか用意していないため、設定を外すことで解消できたと解釈している。