### PR TITLE
ファイルパス指定を修正 #152

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
 
     <%= yield :head %>
 
-    <link rel="manifest" href="/manifest.json"> <!-- PWA対応 -->
+    <link rel="manifest" href="/pwa/manifest.json"> <!-- PWA対応 -->
     <%= favicon_link_tag('favicon.png') %> <!-- ファビコン設定 -->
     <link rel="apple-touch-icon" href="/apple-touch-icon.png"> <!-- Appleデバイス ブックマーク用アイコン設定 -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">


### PR DESCRIPTION
iPhoneのSafariで共有ボタンを押したときに表示される画像がOGP画像になっているため、
manifest.jsonが正しく読み込まれていない可能性を考え、パスの指定を変更して不具合の解消を試みる。

表示はデプロイ後に確認し、結果はこのプルリクのコメントで追加し残す。