### PR TITLE
デフォルトコードを利用する形に変更 #258

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= yield :head %>
 
     <link rel="manifest" href="/manifest.json"> <!-- PWA対応 -->
-    <%= favicon_link_tag('favicon.png') %> <!-- ファビコン設定 -->
+    <link rel="icon" href="/logo.png" type="image/png"> <!-- ファビコン設定 -->
     <link rel="apple-touch-icon" href="/apple-touch-icon.png"> <!-- Appleデバイス ブックマーク用アイコン設定 -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>


### PR DESCRIPTION
iphoneのsafariで共有ボタンを押したときに表示されるアイコンが、
（かなり小さいサイズの）OGP画像になっているため、解消を試みる。

現状の表示
![image](https://github.com/user-attachments/assets/7aa2945d-e742-4383-98e1-6a216085ddfa)

■本番環境にデプロイし、スマホで確認してからCloseする。
変わらなければ、引き続き調査する。