### PR TITLE
apple-touch-iconの設定を削除 #258

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,6 @@
 
     <link rel="manifest" href="/manifest.json"> <!-- PWA対応 -->
     <%= favicon_link_tag('favicon.ico') %> <!-- ファビコン設定 -->
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png"> <!-- Appleデバイス ブックマーク用アイコン設定 -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>


### PR DESCRIPTION
アイコンの表示が上手く反映されない原因として、`favicon.ico`と`apple-touch-icon.png`の設定を行っていることで競合している可能性を考え、一旦コードを`favicon.ico`のみの指定にしてみる。

この修正をデプロイし、画像表示が特に変わらなければ、他の画像ファイルも削除して再度確認する。