### PR TITLE
カバレッジ計測のgem SimpleCovの導入 #270

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+/coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,9 @@ group :development, :test do
   # RSpecの導入
   gem "rspec-rails"
   gem "factory_bot_rails"
+
+  # カバレッジ計測のgem
+  gem "simplecov"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
       reline (>= 0.3.8)
     deep_merge (1.2.2)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     dotenv (3.1.4)
     drb (2.2.1)
     erubi (1.13.0)
@@ -347,6 +348,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -413,6 +420,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-rails-omakase
   selenium-webdriver
+  simplecov
   sorcery
   sprockets-rails
   stimulus-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,8 @@
+# カバレッジ測定のgem　SimpleCovを有効にするために追加
+require 'simplecov'
+SimpleCov.start
+# ここまで
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
Close #270 

### やった事
- [x] [SimpleCov](https://github.com/simplecov-ruby/simplecov) を用いてテストコードのカバレッジ（網羅率）を計測できる状態にした。
- [x] ターミナルで計測がされることを確認した。
![image](https://github.com/user-attachments/assets/cd5f4378-b17c-4860-a7be-a99ea3e5c3ca)

- [x] Userモデルは84％のカバー率であることを確認した。
![image](https://github.com/user-attachments/assets/265ce187-cf50-4f9d-8224-0c347d86c664)
    

---

### 上手くいかなかった点
-  公式READMEで記載のあった、計測時の生成ファイルの展開コマンド（`open coverage/index.html`や`xdg-open coverage/index.html`）ではエラーとなり、ターミナルからのコマンド操作ではブラウザでの確認が困難だった。
-  エラー時に表示されたコマンド`sudo apt install xdg-utils`も試したが、展開できなかった。
- 公式READMEの説明には`in a Mac Terminal（Macのターミナルでは、）`の前置きがあった事から、
自分のWindows(WSL,Ubuntu接続の)環境では記載のコマンドが効かない可能性があると考え、
「ブラウザで確認する事」に焦点を絞り以下の応急的な対処を行った。
    
---
 
### 応急的な対処
- VScodeから上記ファイルをダウンロードし、PCのOneDriveのディレクトリ配下へ配置
![image](https://github.com/user-attachments/assets/e233f429-c5c0-423e-ad37-63077d868a3f)
- chromeアイコンで表示されるため、クリックし、アクセス
![image](https://github.com/user-attachments/assets/e761315b-55fb-4d7e-b57b-36a29c2dc2f4)
- chrome上で確認。→先日のissueで作成したuserモデルテストのカバー率は上記の通り確認できた。また、全体的にも表示内容は確認できる状態の為完了とした。
