### PR TITLE
システムスペックの復習と設定 #166

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -84,4 +84,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,6 +388,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     websocket (1.2.11)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -427,6 +431,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers
 
 RUBY VERSION
    ruby 3.2.3p157

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,7 +28,8 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+# capybara等ファイルの読み込み設定のため、コメントアウトを解除。（spec/support内の.rbファイルをすべて見つけて読み込み）
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -73,4 +74,13 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+
+  # システムスペック実行前にテストを動かすブラウザを設定
+  config.before(:each, type: :system) do
+    driven_by :remote_chrome
+    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
+    Capybara.server_port = 4444
+    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
+    Capybara.ignore_hidden_elements = false
+  end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,8 @@
+Capybara.register_driver :remote_chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('no-sandbox')
+  options.add_argument('headless')
+  options.add_argument('disable-gpu')
+  options.add_argument('window-size=1680,1050')
+  Capybara::Selenium::Driver.new(app, browser: :remote, url: ENV['SELENIUM_DRIVER_URL'], capabilities: options)
+end


### PR DESCRIPTION
Close #166 

### やった事
- [x] カリキュラム[RSpec入門3](https://school.runteq.jp/v3/curriculums/rspec_basic/chapters/3)の復習
- [x] 必要なgem（不足しているgem "webdrivers"）を導入し、テストが書ける状態に設定を行った。
  - gem "webdrivers"の導入
  - formatの設定（RSpecのテスト結果の出力形式の設定）
  - webdriverの設定（system specのテストを実行するブラウザの設定）
     
※テストコードはまだ書いていないため、次のissueで作成する。