### PR TITLE
User関連のシステムスペックを作成（ログイン前） #167

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -25,11 +25,20 @@ services:
       - .:/myapp
     environment:
       TZ: Asia/Tokyo
+      # システムスペックで追記
+      SELENIUM_DRIVER_URL: http://chrome:4444/wd/hub
+      # ここまで
     ports:
       - "3000:3000"
     user: "1000:1000"
     depends_on:
       db:
         condition: service_healthy
+  # システムスペックで追記
+  chrome:
+    image: seleniarm/standalone-chromium:latest
+    ports:
+      - 4444:4444
+  # ここまで
 volumes:
   postgresql_data:

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe "Users", type: :system do
           click_button "登録"
           expect(page).to have_content "ユーザー登録に失敗しました"
           expect(page).to have_content "メールアドレスを入力してください"
-          expect(current_path).to eq new_user_path
+          expect(current_path).to eq users_path # renderメソッドで再表示させる為、new_user_pathへのリダイレクトではない。
         end
       end
 
       context "登録済のメールアドレスを使用" do
         it "ユーザーの新規作成が失敗する" do
-          existed_user = create(:user)
+          existed_user = create(:user, email: "email@example.com")
           visit new_user_path
           fill_in "ユーザー名", with: "test_user"
           fill_in "メールアドレス", with: "email@example.com"
@@ -43,7 +43,7 @@ RSpec.describe "Users", type: :system do
           click_button "登録"
           expect(page).to have_content "ユーザー登録に失敗しました"
           expect(page).to have_content "メールアドレス：このメールアドレスは使用できません。別のメールアドレスをご入力ください。"
-          expect(current_path).to eq new_user_path
+          expect(current_path).to eq users_path
           expect(page).to have_field "メールアドレス", with: "email@example.com"
         end
       end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,9 +1,62 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
-  before do
-    driven_by(:rack_test)
-  end
+  let(:user) { create(:user) }
 
-  pending "add some scenarios (or delete) #{__FILE__}"
+  describe "ログイン前" do
+    describe "ユーザー新規登録" do
+      context "フォームの入力値が正常" do
+        it "ユーザーの新規作成が成功する" do
+          visit new_user_path
+          fill_in "ユーザー名", with: "test_user"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "パスワード", with: "password"
+          fill_in "パスワード再入力", with: "password"
+          click_button "登録"
+          expect(page).to have_content "ユーザー登録が完了しました"
+          expect(current_path).to eq posts_path
+        end
+      end
+
+      context "メールアドレスが未入力" do
+        it "ユーザーの新規作成が失敗する" do
+          visit new_user_path
+          fill_in "ユーザー名", with: "test_user"
+          fill_in "メールアドレス", with: ""
+          fill_in "パスワード", with: "password"
+          fill_in "パスワード再入力", with: "password"
+          click_button "登録"
+          expect(page).to have_content "ユーザー登録に失敗しました"
+          expect(page).to have_content "メールアドレスを入力してください"
+          expect(current_path).to eq new_user_path
+        end
+      end
+
+      context "登録済のメールアドレスを使用" do
+        it "ユーザーの新規作成が失敗する" do
+          existed_user = create(:user)
+          visit new_user_path
+          fill_in "ユーザー名", with: "test_user"
+          fill_in "メールアドレス", with: "email@example.com"
+          fill_in "パスワード", with: "password"
+          fill_in "パスワード再入力", with: "password"
+          click_button "登録"
+          expect(page).to have_content "ユーザー登録に失敗しました"
+          expect(page).to have_content "メールアドレス：このメールアドレスは使用できません。別のメールアドレスをご入力ください。"
+          expect(current_path).to eq new_user_path
+          expect(page).to have_field "メールアドレス", with: "email@example.com"
+        end
+      end
+    end
+
+    describe "マイページ遷移" do
+      context "ログインしていない状態" do
+        it "マイページへのアクセスが失敗する" do
+          visit mypage_path(user)
+          # 後でフラッシュの設定を修正したらコメントアウトを外す expect(page).to have_content "ログインしてください"
+          expect(current_path).to eq login_path
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Close #167 
  
### やった事

- [x] userログイン前のテストケース作成
- [x] テストの実行に不足していた設定をcompose.ymlへ追加（`Errno::ECONNREFUSED`を解消）
- [x] テスト実行時にエラーが出た箇所の修正