### PR TITLE
投稿へ商品名を追加 #106

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgconf-2-4 libasound2
+          sudo apt-get install -y libglib2.0-0 libgtk-3-0 libasound2-plugins
 
       # rubyを実行出来る環境を作る
       - name: Set up Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # 必要なライブラリをインストール
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgconf-2-4 libasound2
+
       # rubyを実行出来る環境を作る
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,12 +106,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 必要なライブラリをインストール
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libglib2.0-0 libgtk-3-0 libasound2-plugins
-
       # rubyを実行出来る環境を作る
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -42,6 +42,7 @@ class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
     @brand_admin = User.find(@post.brand_admin_id) if @post.brand_admin_id.present? # 投稿にブランドが設定されている場合、その情報を取得
+    @product_name = Product.find_by(id: @post.product_id)&.product_name # 商品名の取得
 
     # 自分の投稿ならそのまま表示し、他ユーザーの投稿であれば、公開ステータスだけを表示する
     if

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -94,9 +94,18 @@ class PostsController < ApplicationController
     @favorite_posts = current_user.favorite_posts.published.includes(:user).order(created_at: :desc)
   end
 
+  def product_select
+    @brand = User.find(params[:id])
+    @products = @brand.products
+
+    respond_to do |format|
+      format.json { render json: @products }
+    end
+  end
+
   private
 
   def post_params
-    params.require(:post).permit(:body, :used_year, :brand_admin_id, :color, :care_item, :care_frequency, :care_howto, :status, post_image: [], post_image_cache: [])
+    params.require(:post).permit(:body, :used_year, :brand_admin_id, :product_id, :color, :care_item, :care_frequency, :care_howto, :status, post_image: [], post_image_cache: [])
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import ProductSelectController from "./product_select_controller"
+application.register("product-select", ProductSelectController)
+
 import SearchController from "./search_controller"
 application.register("search", SearchController)
 

--- a/app/javascript/controllers/product_select_controller.js
+++ b/app/javascript/controllers/product_select_controller.js
@@ -5,7 +5,15 @@ export default class extends Controller {
   static targets = ["products"]
 
   onChange(event) {
-    this.updateProducts(event.target.value) // 商品一覧を更新するメソッドを呼び出す。（イベントが発火した時の値を取得＝セレクトボックスの値）
+    const brandAdminId = event.target.value
+
+    // ブランドが未選択の場合、商品セレクトボックスを初期化
+    if (!brandAdminId) {
+      this.productsTarget.innerHTML = "<option value=''>ブランドを選択</option>"
+      return
+    }
+
+    this.updateProducts(brandAdminId) // 商品一覧を更新するメソッドを呼び出す。（イベントが発火した時の値を取得＝セレクトボックスの値）
   }
 
   updateProducts(brandAdminId) {

--- a/app/javascript/controllers/product_select_controller.js
+++ b/app/javascript/controllers/product_select_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="product-select"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/product_select_controller.js
+++ b/app/javascript/controllers/product_select_controller.js
@@ -2,6 +2,24 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="product-select"
 export default class extends Controller {
-  connect() {
+  static targets = ["products"]
+
+  onChange(event) {
+    this.updateProducts(event.target.value) // 商品一覧を更新するメソッドを呼び出す。（イベントが発火した時の値を取得＝セレクトボックスの値）
+  }
+
+  updateProducts(brandAdminId) {
+    fetch(`/posts/${brandAdminId}/product_select.json`)
+    .then(response => response.json())
+    .then(data => {
+      if (data.length === 0) {
+        // 登録商品がない場合
+        this.productsTarget.innerHTML = "<option value=''>登録商品なし</option>"
+      } else {
+        // 登録商品がある場合
+        let options = data.map(product => `<option value="${product.id}">${product.product_name}</option>`)
+        this.productsTarget.innerHTML = options.join("")
+      }
+    })
   }
 }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: post do |f| %>
+<%= form_with model: post, data: { turbo: false } do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
 
   <%= f.label :post_image, '画像を選択（5枚まで）', class: 'label w-10/12 md:w-1/2 mx-auto pt-4 font-medium'%>
@@ -57,19 +57,21 @@
     </div>
   </div>
 
-  <!-- ブランド選択 -->
-  <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4">
-    <%= f.label :brand_admin_id, 'ブランド', class: 'label font-medium mr-4 w-1/2' %>
-    <div class="rounded-lg border border-neutral-200 w-full">
-      <%= f.select :brand_admin_id, @brand_admins.collect { |brand_admin| [brand_admin.name, brand_admin.id] }, { include_blank: "未選択" }, class: 'select w-full' %>
+  <div data-controller="product-select">
+    <!-- ブランド選択 -->
+    <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4">
+      <%= f.label :brand_admin_id, 'ブランド', class: 'label font-medium mr-4 w-1/2' %>
+      <div class="rounded-lg border border-neutral-200 w-full">
+        <%= f.select :brand_admin_id, @brand_admins.collect { |brand_admin| [brand_admin.name, brand_admin.id] }, { include_blank: "未選択" }, class: "select w-full", data: { action: "change->product-select#onChange" } %>
+      </div>
     </div>
-  </div>
 
-  <!-- 商品選択 -->
-  <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4">
-    <%= f.label :product_id, '商品名', class: 'label font-medium mr-4 w-1/2' %>
-    <div class="rounded-lg border border-neutral-200 w-full">
-      <%= f.select :product_id, [], { include_blank: "商品を選択" }, class: 'select w-full', id: "product-select" %>
+    <!-- 商品選択 -->
+    <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4">
+      <%= f.label :product_id, '商品名', class: 'label font-medium mr-4 w-1/2' %>
+      <div class="rounded-lg border border-neutral-200 w-full">
+        <%= f.select :product_id, [], { include_blank: "ブランドを先に選択してください" }, class: "select w-full", data: { "product-select-target": "products"} %>
+      </div>
     </div>
   </div>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -70,7 +70,7 @@
     <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4">
       <%= f.label :product_id, '商品名', class: 'label font-medium mr-4 w-1/2' %>
       <div class="rounded-lg border border-neutral-200 w-full">
-        <%= f.select :product_id, [], { include_blank: "ブランドを先に選択してください" }, class: "select w-full", data: { "product-select-target": "products"} %>
+        <%= f.select :product_id, [], { include_blank: "ブランドを選択" }, class: "select w-full", data: { "product-select-target": "products"} %>
       </div>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -92,6 +92,22 @@
   </div>
 </div>
 
+<!-- 商品情報 -->
+<div class="product">
+  <div class="flex w-full px-4 pt-4 md:px-0 md:pt-4 md:w-1/2 mx-auto text-yellow-900">
+    <div class="w-1/5">
+      <p>商品名 </p>
+    </div>
+    <div class="w-4/5">
+      <% if @product_name %>
+        <p><%= @product_name %></p>
+      <% else %>
+        <p>未登録</p>
+      <% end %>
+    </div>
+  </div>
+</div>
+
 <!-- カラー -->
 <div class="color">
   <div class="flex w-full px-4 pt-4 pb-10 md:px-0 md:pt-4 md:pb-10 md:w-1/2 mx-auto text-yellow-900">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
 
   # 投稿機能関連
   resources :posts, only: %i[index new create show edit update destroy] do
+    get "product_select", on: :member
     collection do
       get :favorites
     end

--- a/db/migrate/20241220143213_add_product_id_to_posts.rb
+++ b/db/migrate/20241220143213_add_product_id_to_posts.rb
@@ -1,0 +1,6 @@
+class AddProductIdToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :posts, :product_id, :integer
+    add_index :posts, :product_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_16_184613) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_20_143213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,7 +46,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_184613) do
     t.text "care_howto"
     t.integer "status", default: 0, null: false
     t.string "color"
+    t.integer "product_id"
     t.index ["brand_admin_id"], name: "index_posts_on_brand_admin_id"
+    t.index ["product_id"], name: "index_posts_on_product_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
Close #106 
    
### やった事
動的セレクトボックスの実装を行った。
- [x] Stimulusコントローラーの作成
- [x] htmlでイベントの発火コードを追加
- [x] Stimulusコントローラーで、ブランド名が選択された時に、値を取得するイベントを作成
- [x] Stimulusコントローラーで、選択されたブランドの値をもとに商品データを取得するイベントを作成
- [x] 商品データを取得するイベントに対応するルーティングの設定
- [x] postsコントローラーに、商品データを取得するイベントに対応するアクションを追加
- [x] postsコントローラーに、フォームから取得するパラメーターを追加
- [x] 投稿詳細画面で商品名を表示

### できなかった事
- 投稿を登録する際にバリデーションエラーで戻ってきた場合、選択した商品名の保持が出来ていない。

この問題は別issueを立てて対応する。