### PR TITLE
動的セレクトボックスの値が保持できない問題の対処 #287

### DIFF
--- a/app/controllers/brand_admin/products_controller.rb
+++ b/app/controllers/brand_admin/products_controller.rb
@@ -2,7 +2,7 @@ class BrandAdmin::ProductsController < ApplicationController
   skip_before_action :check_brand_admin, only: %i[show]
 
   def index
-    @products = current_user.products.includes(:user).order(created_at: :desc)
+    @products = current_user.products.includes(:user).order(product_name: :asc)
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,11 +8,13 @@ class PostsController < ApplicationController
   def new
     @post = Post.new
     @brand_admins = User.brand_admins # スコープでブランド管理者のユーザーを取得
+    @products = Product.all
   end
 
   def create
     @post = current_user.posts.build(post_params)
     @post.brand_admin_id = params[:post][:brand_admin_id].presence # nilまたは空文字の場合は自動的にnilになる
+    @products = Product.all
 
     # params[:draft]があれば下書き、params[:unpublished]があれば非公開、どちらもなければ公開投稿
     @post.status =
@@ -55,11 +57,13 @@ class PostsController < ApplicationController
   def edit
     @post = current_user.posts.find(params[:id])
     @brand_admins = User.brand_admins # スコープ
+    @products = Product.all
   end
 
   def update
     @post = current_user.posts.find(params[:id])
     @brand_admins = User.brand_admins # スコープ
+    @products = Product.all
 
     # params[:published]があれば公開、params[:unpublished]があれば非公開、どちらもなければ下書き
     @post.status =

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,11 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 
+    <!-- デベロッパーツールの警告対処・プレロードの設定 -->
+    <link rel="preload" href="<%= asset_path 'application.css' %>" as="style">
+    <link rel="stylesheet" href="<%= asset_path 'application.css' %>">
+    <!-- ここまで -->
+
     <!-- 本番環境のみでGoogle tag (gtag.js)を表示 -->
     <% if Rails.env.production? %>
       <script async src="https://www.googletagmanager.com/gtag/js?id=G-WNV542D8LF"></script>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -71,7 +71,7 @@
     <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4">
       <%= f.label :product_id, '商品名', class: 'label font-medium mr-4 w-1/2' %>
       <div class="rounded-lg border border-neutral-200 w-full">
-          <%= f.select :product_id, options_for_select(@products.select { |product| product.user_id == @post.brand_admin_id }.map { |product| [product.product_name, product.id] }, @post.product_id),{ include_blank: "ブランドを選択" }, class: "select w-full", data: { "product-select-target": "products" } %>
+          <%= f.select :product_id, @products.select { |product| product.user_id == @post.brand_admin_id }.map { |product| [product.product_name, product.id] }, { selected: @post.product_id, include_blank: "ブランドを選択" }, class: "select w-full", data: { "product-select-target": "products" } %>
       </div>
     </div>
   </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -57,6 +57,7 @@
     </div>
   </div>
 
+  <!-- 動的セレクトボックス -->
   <div data-controller="product-select">
     <!-- ブランド選択 -->
     <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4">
@@ -70,21 +71,10 @@
     <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4">
       <%= f.label :product_id, '商品名', class: 'label font-medium mr-4 w-1/2' %>
       <div class="rounded-lg border border-neutral-200 w-full">
-        <% if @post.product_id.present? %>
           <%= f.select :product_id, options_for_select(@products.select { |product| product.user_id == @post.brand_admin_id }.map { |product| [product.product_name, product.id] }, @post.product_id),{ include_blank: "ブランドを選択" }, class: "select w-full", data: { "product-select-target": "products" } %>
-        <% else %>
-          <%= f.select :product_id, [], { include_blank: "ブランドを選択" }, class: "select w-full", data: { "product-select-target": "products" } %>
-        <% end %>
       </div>
-
-      <% @brand_admins.each do |brand_admin| %>
-        <template id="products-of-brand<%= brand_admin.id %>">
-          <% brand_admin.products.each do |product| %>
-            <option value="<%= product.id %>"><%= product.product_name %></option>
-          <% end %>
-        </template>
-      <% end %>
     </div>
+  </div>
 
   <!-- カラー選択 -->
   <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4 mb-6">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -70,10 +70,21 @@
     <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4">
       <%= f.label :product_id, '商品名', class: 'label font-medium mr-4 w-1/2' %>
       <div class="rounded-lg border border-neutral-200 w-full">
-        <%= f.select :product_id, [], { include_blank: "ブランドを選択" }, class: "select w-full", data: { "product-select-target": "products"} %>
+        <% if @post.product_id.present? %>
+          <%= f.select :product_id, options_for_select(@products.select { |product| product.user_id == @post.brand_admin_id }.map { |product| [product.product_name, product.id] }, @post.product_id),{ include_blank: "ブランドを選択" }, class: "select w-full", data: { "product-select-target": "products" } %>
+        <% else %>
+          <%= f.select :product_id, [], { include_blank: "ブランドを選択" }, class: "select w-full", data: { "product-select-target": "products" } %>
+        <% end %>
       </div>
+
+      <% @brand_admins.each do |brand_admin| %>
+        <template id="products-of-brand<%= brand_admin.id %>">
+          <% brand_admin.products.each do |product| %>
+            <option value="<%= product.id %>"><%= product.product_name %></option>
+          <% end %>
+        </template>
+      <% end %>
     </div>
-  </div>
 
   <!-- カラー選択 -->
   <div class="flex items-center mx-auto w-10/12 md:w-1/2 pt-4 mb-6">


### PR DESCRIPTION
Close #287 
関連プルリク #286 
関連issue #106

### やった事
ブランドごとのtemplateを用意しておき、@postにproduct_idを持っている場合は
@postのbrand_admin_id(=user_id)と一致するtemplateを選択、
そこからproduct_idと一致する商品データをセレクトボックスに表示させるようにした。

- [x] app/views/posts/_form.html.erbにtemplateの追加
- [x] また、@postにproduct_idを持っている場合はtemplateから選択するように修正
- [x] コントローラーでProdcutモデルのデータを取得するために変数を定義
- [x] コントローラーの重複コードをprivateメソッドでまとめる修正

ついでの修正↓
- [x] デベロッパーツールでプレロードに関するエラーが出ていた為対処
- [x] 商品一覧も商品名で昇順になるように修正

### 出来るようになったこと

- バリデーションエラーの後に表示される画面で選択した値の保持
- 編集画面を開いたときに登録済の値の保持
- 値が保持されたセレクトボックスを開いたときにも、選択されているブランドが持つ商品のみを表示させる
- ブランドを変更すると、適切な商品が商品名のセレクトボックスに表示される