### PR TITLE
画像が(バリデーションエラー時・編集時)保持出来ない問題の対処 #118

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -34,7 +34,7 @@ class PostsController < ApplicationController
         redirect_to posts_path, success: "投稿を公開しました"
       end
     else
-      flash.now[:danger] = "投稿メッセージを入力していないと投稿できません"
+      flash.now[:danger] = "投稿の作成に失敗しました"
       render :new, status: :unprocessable_entity
     end
   end
@@ -78,7 +78,7 @@ class PostsController < ApplicationController
         redirect_to post_path(@post), success: "投稿を更新しました"
       end
     else
-      flash.now[:danger] = "投稿メッセージを入力していないと投稿できません"
+      flash.now[:danger] = "投稿の更新に失敗しました"
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -105,7 +105,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:body, :used_year, :brand_admin_id, :product_id, :color, :care_item, :care_frequency, :care_howto, :status, post_image: [], post_image_cache: [])
+    params.require(:post).permit(:body, :post_image, :post_image_cache, :used_year, :brand_admin_id, :product_id, :color, :care_item, :care_frequency, :care_howto, :status)
   end
 
   def set_brand_admins

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -1,0 +1,42 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="image-preview"
+export default class extends Controller {
+  static targets = ["input", "preview", "existing"]
+
+  previewImage() {
+    const input = this.inputTarget // htmlの画像読込の要素
+    const preview = this.previewTarget // htmlのプレビューを表示させる要素
+    const files = input.files // ユーザーが選択したファイル
+    const width = this.data.get('width')　// htmlで指定した画像の幅
+    const height = this.data.get('height')　// htmlで指定した画像の高さ
+    const existing = this.existingTarget　// キャッシュや登録済の画像を表示する要素
+
+    // 既存の画像を非表示にする
+    if (existing) {
+      existing.style.display = 'none';
+    }
+
+    // filesは<input type="file"> 要素で選択されているファイルのリスト
+    // filesは空でもFileListオブジェクトは存在するのでtrueとなる
+    // files[0]はfilesリストの最初の要素を示している。
+    // 「ユーザーが少なくとも1つのファイルを選択していて、それにアクセスできる状態である」という条件文
+    if (files && files[0]) {
+    const reader = new FileReader() // 変数readerをFileReaderオブジェクトとして定義。非同期にファイルを読み込むことができる
+
+    // 変数readerにファイル読み込みが完了した(onload)場合に、実行される関数。(e)はイベントオブジェクト。
+    reader.onload = (e) => {
+        preview.innerHTML = `<img src="${e.target.result}" style="max-width: ${width}px; max-height: ${height}px;">`;
+        }
+        // previewのターゲット要素にHTMLを追加する
+        // e.target.resultには読み込んだファイルの内容が含まれており、これはBase64エンコーディングされたデータURLの形式で提供される
+        // このデータURLを画像のsrc属性に設定することで、ブラウザ上に画像を直接表示することが可能になる
+    reader.readAsDataURL(files[0])
+    // readerに対してreadAsDataURLメソッドを使う
+    // readAsDataURLメソッドはfileの内容を読み込み、データURLとして返す(Base64エンコーディングされた文字列)メソッド
+    // ユーザーがfilesからファイルを選択した時、そのファイルはfiles配列の0番目に格納されるので内容を非同期に読み込み、その内容をデータURLとして保持
+    // 読み込みが完了すると、FileReader オブジェクトの onload イベントが発火
+    // 読み込まれたファイルのデータは e.target.result を通じてアクセス可能になる
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import ImagePreviewController from "./image_preview_controller"
+application.register("image-preview", ImagePreviewController)
+
 import ProductSelectController from "./product_select_controller"
 application.register("product-select", ProductSelectController)
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,6 @@
 class Post < ApplicationRecord
-  mount_uploaders :post_image, PostImageUploader
+  mount_uploader :post_image, PostImageUploader
 
-  validates :post_image, length: { maximum: 5 }
   validates :body, presence: true, length: { maximum: 2000 }
   validates :care_item, length: { maximum: 700 }
   validates :care_howto, length: { maximum: 1000 }

--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -67,7 +67,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
 
   # 拡張子を.webpで保存
   def filename
-    super.chomp(File.extname(super)) + ".webp" if original_filename.present?
+    super.chomp(File.extname(super)) + ".webp"
   end
 
   private

--- a/app/views/brand_admin/posts/_post.html.erb
+++ b/app/views/brand_admin/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <div class="card rounded-xl bg-base-100 shadow-md aspect-[1/1] text-yellow-900">
   <div class="card-image" style="height: 75%;">
-    <%= link_to image_tag(post.post_image.first.url, class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
+    <%= link_to image_tag(post.post_image.url, class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
   </div>
 
   <div class="flex justify-between items-center mx-3 py-1 border-b">

--- a/app/views/brand_admin/posts/_post.html.erb
+++ b/app/views/brand_admin/posts/_post.html.erb
@@ -1,10 +1,6 @@
 <div class="card rounded-xl bg-base-100 shadow-md aspect-[1/1] text-yellow-900">
   <div class="card-image" style="height: 75%;">
-    <% if post.post_image.present? %>
-      <%= link_to image_tag(post.post_image.first.url, class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
-    <% else %>
-      <%= link_to image_tag('no_image.png', class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
-    <% end %>
+    <%= link_to image_tag(post.post_image.first.url, class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
   </div>
 
   <div class="flex justify-between items-center mx-3 py-1 border-b">

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,13 +1,21 @@
 <%= form_with model: post, data: { turbo: false } do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
 
-  <%= f.label :post_image, '画像を選択', class: 'label w-10/12 md:w-1/2 mx-auto pt-4 font-medium'%>
-  <%= f.file_field :post_image, class: 'file-input file-input-bordered form-control w-10/12 md:w-1/2 mx-auto', accept: 'image/*' %>
-  <%= f.hidden_field :post_image_cache %>
+  <!-- 投稿画像 -->
+  <div data-controller="image-preview" data-image-preview-width="250" data-image-preview-height="250">
+    <%= f.label :post_image, '画像選択', class: 'label w-10/12 md:w-1/2 mx-auto pt-4 font-medium'%>
+    <%= f.file_field :post_image, class: 'file-input file-input-bordered form-control w-10/12 md:w-1/2 mx-auto', accept: 'image/*', data: { "image-preview-target": "input", action: "change->image-preview#previewImage"} %>
+    <%= f.hidden_field :post_image_cache %>
 
-  <!-- サムネイル表示 -->
-  <div class="flex justify-center mt-4 mb-4">
-    <%= image_tag(post.post_image_url, class: 'h-40 w-40 border-2 object-contain') if post.post_image? %>
+      <!-- 画像の説明 -->
+    <div class="flex justify-center mt-2">
+      <p class="text-center text-sm">以下に表示される画像が登録されます</p>
+    </div>
+    <!-- サムネイル表示 -->
+    <div class="flex justify-center mt-4 mb-4" data-image-preview-target="existing">
+      <%= image_tag(post.post_image_url, class: 'h-60 w-60 border-2 object-contain') if post.post_image? %>
+    </div>
+    <div class="flex justify-center mt-4 mb-4" data-image-preview-target="preview"></div>
   </div>
 
   <!-- 投稿メッセージ -->

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,27 +1,13 @@
 <%= form_with model: post, data: { turbo: false } do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
 
-  <%= f.label :post_image, '画像を選択（5枚まで）', class: 'label w-10/12 md:w-1/2 mx-auto pt-4 font-medium'%>
-  <%= f.file_field :post_image, multiple: true, include_hidden: false, class: 'file-input file-input-bordered form-control w-10/12 md:w-1/2 mx-auto'%>
-  <%= f.hidden_field :post_image, multiple: true %>
+  <%= f.label :post_image, '画像を選択', class: 'label w-10/12 md:w-1/2 mx-auto pt-4 font-medium'%>
+  <%= f.file_field :post_image, class: 'file-input file-input-bordered form-control w-10/12 md:w-1/2 mx-auto', accept: 'image/*' %>
+  <%= f.hidden_field :post_image_cache %>
 
   <!-- サムネイル表示 -->
-  <div class="thumbnail w-10/12 md:w-1/2 mx-auto py-3 text-sm">
-    <% if post.post_image.any? %>
-      <p>【編集前の画像】　※画像の追加・変更の場合も、登録する画像すべてを選択してください。</p>
-      <div class="flex flex-wrap">
-        <% post.post_image.each do |image| %>
-          <div class="thumbnail-image-wrapper m-1 w-24 h-24 overflow-hidden flex items-center justify-center border border-neutral-200">
-            <%= image_tag image.url, alt: "サムネイル", class: "thumbnail-image max-w-full max-h-full object-cover" %>
-          </div>
-        <% end %>
-      </div>
-    <% else %>
-      <p>画像を選択していない場合、以下のデフォルト画像が設定されます。</p>
-      <div class="thumbnail-image-wrapper w-24 h-24">
-        <%= image_tag 'no_image.png', alt: "デフォルト画像", class: "thumbnail-image max-w-full max-h-full object-cover" %>
-      </div>
-    <% end %>
+  <div class="flex justify-center mt-4 mb-4">
+    <%= image_tag(post.post_image_url, class: 'h-40 w-40 border-2 object-contain') if post.post_image? %>
   </div>
 
   <!-- 投稿メッセージ -->

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,10 +1,6 @@
 <div class="card rounded-xl bg-base-100 shadow-md aspect-[1/1] text-yellow-900">
   <div class="card-image" style="height: 75%;">
-    <% if post.post_image.present? %>
-      <%= link_to image_tag(post.post_image.first.url, class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
-    <% else %>
-      <%= link_to image_tag('no_image.png', class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
-    <% end %>
+    <%= link_to image_tag(post.post_image.url, class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
   </div>
 
   <div class="flex justify-between items-center mx-3 py-1 border-b">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,26 +9,7 @@
 </div>
 
 <div class="relative w-full md:w-1/2 mx-auto">
-  <div class="overflow-hidden relative">
-    <div class="flex transition-transform duration-500 ease-in-out" id="carouselItems">
-      <% if @post.post_image.present? %>
-        <% @post.post_image.each_with_index do |image, index| %>
-          <div class="carousel-item <%= 'active' if index.zero? %> w-full">
-            <%= image_tag(image.url, class: 'block w-full h-auto object-contain') %>
-          </div>
-        <% end %>
-      <% else %>
-        <div class="carousel-item active w-full">
-          <%= image_tag('no_image.png', class: 'block w-full h-auto object-contain') %>
-        </div>
-      <% end %>
-    </div>
-  </div>
-  <% if @post.post_image.count > 1 %>
-    <!-- 画像が複数枚ある場合のみ表示 -->
-    <button class="absolute left-1 top-1/2 transform -translate-y-1/2 bg-gray-200 bg-opacity-60 shadow-md text-white w-10 h-10 rounded-full" onclick="prevSlide()">❮</button>
-    <button class="absolute right-1 top-1/2 transform -translate-y-1/2 bg-gray-200 bg-opacity-60 shadow-md text-white w-10 h-10 rounded-full" onclick="nextSlide()">❯</button>
-  <% end %>
+  <%= image_tag(@post.post_image.url, class: 'block w-full h-auto object-contain') %>
 </div>
 
 <!-- 日付・お気に入りボタン -->
@@ -194,46 +175,3 @@
     <%= link_to "編集", edit_post_path(@post), class: "btn w-1/3 bg-[#E6CCB585] hover:bg-[#fdba74] text-yellow-900", id: "button-edit-#{@post.id}" %>
   </div>
 <% end %>
-
-<script>
-  let currentIndex = 0;
-
-  function showSlide(index) {
-    const slides = document.querySelectorAll('.carousel-item');
-    currentIndex = (index + slides.length) % slides.length;
-
-    const offset = -currentIndex * 100;
-    document.getElementById('carouselItems').style.transform = `translateX(${offset}%)`;
-
-    slides.forEach((slide, i) => slide.classList.toggle('active', i === currentIndex));
-  }
-
-  function nextSlide() {
-    showSlide(currentIndex + 1);
-  }
-
-  function prevSlide() {
-    showSlide(currentIndex - 1);
-  }
-
-  // スワイプ機能
-  const carousel = document.getElementById('carouselItems');
-  let startX;
-
-  carousel.addEventListener('touchstart', (event) => {
-    startX = event.touches[0].clientX;
-  });
-
-  carousel.addEventListener('touchend', (event) => {
-    const endX = event.changedTouches[0].clientX;
-    const distanceX = endX - startX;
-
-    if (distanceX > 30) {
-      prevSlide(); // 右スワイプ
-    } else if (distanceX < -30) {
-      nextSlide(); // 左スワイプ
-    }
-  });
-
-  showSlide(currentIndex); // 最初のスライドを表示
-</script>


### PR DESCRIPTION
Close #118 
### やった事

- [x] 投稿画像の登録を複数枚から１枚に変更
- [x] プレビュー表示を動的に行えるようにし、ユーザビリティを向上させた

### できなかった事
- 複数枚の画像を登録した場合のキャッシュの維持

### プルリクエストの状態に修正した経緯
問題の解消も試みたが、複数画像の登録自体を見直し、単一登録と比較したときに、
以下の点で単一の方がユーザーの使用感においてメリットが大きいと考え、方向変換した。

- 今回のアプリの目的達成のために複数画像の登録が必須の条件ではない事
- 登録画像が少なくなることによって、投稿の登録時や詳細ページの展開時の速度遅延が軽減される可能性が高い事
- ユーザーにとって気軽に投稿しやすくなる事