### PR TITLE
アカウント削除機能の追加 #290

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -41,7 +41,11 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
-    @brand_admin = User.find(@post.brand_admin_id) if @post.brand_admin_id.present? # 投稿にブランドが設定されている場合、その情報を取得
+    # 投稿のブランドidに一致するuserが見つかれば、その情報を取得、
+    # 見つからなければnilを代入しエラーハンドリングを行う：brand_admin_id(アイテム情報のブランド)を未選択状態(nil)にする
+    @brand_admin = User.find_by(id: @post.brand_admin_id) || begin
+      @post.brand_admin_id = nil
+    end
     @product_name = Product.find_by(id: @post.product_id)&.product_name # 商品名の取得
 
     # 自分の投稿ならそのまま表示し、他ユーザーの投稿であれば、公開ステータスだけを表示する

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,5 @@
 class ProfilesController < ApplicationController
-  before_action :set_user, only: %i[edit update]
+  before_action :set_user, only: %i[edit update destroy]
 
   def show; end
 
@@ -15,6 +15,13 @@ class ProfilesController < ApplicationController
       flash.now[:danger] = "ユーザー情報の更新に失敗しました"
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @user.destroy!
+    # セッションをクリアしてユーザーをログアウト状態にする
+    reset_session
+    redirect_to root_path, status: :see_other, success: "アカウントを削除しました。"
   end
 
   private

--- a/app/views/brand_admin/shared/_header.html.erb
+++ b/app/views/brand_admin/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <!-- 大画面用 -->
 <div class="hidden lg:block">
-  <div class="fixed top-0 start-0 bottom-0 z-[60] w-60 border-e-2 border-neutral-100 pt-7 pb-10 overflow-y-auto lg:block lg:translate-x-0 lg:end-auto lg:bottom-0">
+  <div class="fixed top-0 start-0 bottom-0 z-50 w-60 border-e-2 border-neutral-100 pt-7 pb-10 overflow-y-auto lg:block lg:translate-x-0 lg:end-auto lg:bottom-0">
       <div class="px-6 flex flex-col">
         <%= link_to root_path, class: "btn btn-ghost flex items-center text-xl rounded-lg justify-start font-bold hover:bg-white" do %>
           <span>LeatherPalette ブランド</span>
@@ -81,7 +81,7 @@
 
 <!-- 中画面用 -->
 <div class="hidden md:block lg:hidden">
-  <div class="fixed top-0 start-0 bottom-0 z-[60] w-20 border-e-2 border-neutral-100">
+  <div class="fixed top-0 start-0 bottom-0 z-50 w-20 border-e-2 border-neutral-100">
     <div class="flex flex-col justify-center items-center gap-y-4 py-5">
       <div class="mt-5 mb-4 font-bold">
         <%= link_to root_path, class: "flex-none text-lg font-semibold" do  %>
@@ -162,7 +162,7 @@
 </div>
 
 <!-- スマホ用 -->
-<div class="flex flex-wrap md:hidden sm:justify-start sm:flex-nowrap w-full border-b-2 border-neutral-100 text-sm py-2">
+<div class="flex flex-wrap md:hidden sm:justify-start sm:flex-nowrap w-full border-b-2 border-neutral-100 bg-beige text-sm py-2 fixed top-0 left-0 right-0 z-50">
   <nav class="max-w-[85rem] w-full mx-auto px-2" aria-label="Global">
     <div class="flex items-center justify-between">
       <div>
@@ -172,7 +172,7 @@
           <li>
             <details class="relative border rounded-lg">
               <summary class="font-medium">menu</summary>
-                <ul class="absolute top-[22px] z-50 right-0 shadow rounded-box w-48 font-semibold">
+                <ul class="absolute top-[22px] right-0 shadow rounded-box w-48 font-semibold">
                   <li>
                     <%= link_to brand_admin_mypage_path, class: "dropdown-content flex items-center text-sm rounded-lg justify-start" do %>
                       <i class="bi bi-person-circle text-lg"></i>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,8 +58,8 @@
         <%= yield %>
       </div>
     </main>
-    <footer class="footer footer-center p-10 text-neutral-300 mt-16 md:mt-4 sm:mt-0">
-      <div class="lg:ml-64 md:ml-20 min-[320px]:mb-14 md:mb-0">
+    <footer class="footer footer-center p-10 mt-16 md:mt-4 sm:mt-0">
+      <div class="lg:ml-64 md:ml-20 min-[320px]:mb-14 md:mb-0 z-10">
        <%= render 'shared/footer' %>
       </div>
     </footer>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -25,3 +25,7 @@
     <%= link_to "編集", edit_profile_path, class: "btn w-full md:w-1/2 mb-5 bg-[#E6CCB585] hover:bg-[#fdba74] text-yellow-900" %>
   </div>
 </div>
+
+<div class="p-6 mt-20 flex justify-center w-5/6 mx-auto">
+  <%= link_to "アカウント削除", profile_path, data: { turbo_method: "delete", turbo_confirm: "アカウントを削除すると、投稿やお気に入り等の関連情報もすべて削除されます。本当に削除してよろしいですか？" }, class: "btn w-full md:w-1/2 mb-5 bg-[#e5e5e5] hover:bg-[#a3a3a3]" %>
+</div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <!-- 大画面用 -->
 <div class="hidden lg:block">
-  <div class="fixed top-0 start-0 bottom-0 z-[60] w-60 border-e-2 border-neutral-100 pt-7 pb-10 overflow-y-auto lg:block lg:translate-x-0 lg:end-auto lg:bottom-0">
+  <div class="fixed top-0 start-0 bottom-0 z-50 w-60 border-e-2 border-neutral-100 pt-7 pb-10 overflow-y-auto lg:block lg:translate-x-0 lg:end-auto lg:bottom-0">
       <div class="px-6 flex flex-col">
         <%= link_to root_path, class: "btn btn-ghost flex items-center text-xl rounded-lg justify-start font-bold hover:bg-white" do %>
           <span>LeatherPalette</span>
@@ -46,7 +46,7 @@
 
 <!-- 中画面用 -->
 <div class="hidden md:block lg:hidden">
-  <div class="fixed top-0 start-0 bottom-0 z-[60] w-20 border-e-2 border-neutral-100">
+  <div class="fixed top-0 start-0 bottom-0 z-50 w-20 border-e-2 border-neutral-100">
     <div class="flex flex-col justify-center items-center gap-y-4 py-5">
       <div class="mt-5 mb-4 font-bold">
         <%= link_to root_path, class: "flex-none text-xl font-semibold" do  %>
@@ -96,7 +96,7 @@
 
 
 <!-- スマホ用ボトムナビゲーション -->
-<div class="fixed inset-x-0 bottom-0 z-10 bg-beige border-t-2 border-neutral-100 shadow-md md:hidden">
+<div class="fixed inset-x-0 bottom-0 z-50 bg-beige border-t-2 border-neutral-100 shadow-md md:hidden">
   <div class="flex flex-row justify-between items-center pb-5 px-2">
     <div class="inline-block flex-1">
       <%= link_to posts_path, class:"flex flex-col items-center py-2 px-1 rounded-lg hover:bg-neutral-100", data: { turbo: false } do %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <!-- 大画面用 -->
 <div class="hidden lg:block">
-  <div class="fixed top-0 start-0 bottom-0 z-[60] w-60 border-e-2 border-neutral-100 pt-7 pb-10 overflow-y-auto lg:block lg:translate-x-0 lg:end-auto lg:bottom-0">
+  <div class="fixed top-0 start-0 bottom-0 z-50 w-60 border-e-2 border-neutral-100 pt-7 pb-10 overflow-y-auto lg:block lg:translate-x-0 lg:end-auto lg:bottom-0">
       <div class="px-6 flex flex-col">
         <%= link_to root_path, class: "btn btn-ghost flex items-center text-xl rounded-lg justify-start font-bold hover:bg-white" do %>
           <span>LeatherPalette</span>
@@ -65,7 +65,7 @@
 
 <!-- 中画面用 -->
 <div class="hidden md:block lg:hidden">
-  <div class="fixed top-0 start-0 bottom-0 z-[60] w-20 border-e-2 border-neutral-100">
+  <div class="fixed top-0 start-0 bottom-0 z-50 w-20 border-e-2 border-neutral-100">
     <div class="flex flex-col justify-center items-center gap-y-4 py-5">
       <div class="mt-5 mb-4 font-bold">
         <%= link_to root_path, class: "flex-none text-lg font-semibold" do  %>
@@ -131,7 +131,7 @@
 </div>
 
 <!-- スマホ用 -->
-<div class="flex flex-wrap md:hidden sm:justify-start sm:flex-nowrap w-full border-b-2 border-neutral-100 text-sm py-2">
+<div class="flex flex-wrap md:hidden sm:justify-start sm:flex-nowrap w-full border-b-2 border-neutral-100 bg-beige text-sm py-2 fixed top-0 left-0 right-0 z-50">
   <nav class="max-w-[85rem] w-full mx-auto px-2" aria-label="Global">
     <div class="flex items-center justify-between">
       <div>
@@ -141,7 +141,7 @@
           <li>
             <details class="relative border rounded-lg">
               <summary class="font-medium">menu</summary>
-                <ul class="absolute top-[22px] z-50 right-0 shadow rounded-box w-48 font-semibold">
+                <ul class="absolute top-[22px] right-0 shadow rounded-box w-48 font-semibold">
                   <li>
                     <%= link_to mypage_path, class: "dropdown-content flex items-center text-sm rounded-lg justify-start" do %>
                       <i class="bi bi-person-circle text-lg"></i>
@@ -175,7 +175,7 @@
 </div>
 
 <!-- スマホ用ボトムナビゲーション -->
-<div class="fixed inset-x-0 bottom-0 z-10 bg-beige border-t-2 border-neutral-100 shadow-md md:hidden">
+<div class="fixed inset-x-0 bottom-0 z-50 bg-beige border-t-2 border-neutral-100 shadow-md md:hidden">
   <div class="flex flex-row justify-between items-center pb-5 px-2">
     <div class="inline-block flex-1">
       <%= link_to posts_path, class:"flex flex-col items-center py-2 px-1 rounded-lg hover:bg-neutral-100", data: { turbo: false } do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
   resource :mypage, only: %i[show]
 
   # プロフィール
-  resource :profile, only: %i[show edit update]
+  resource :profile, only: %i[show edit update destroy]
 
   # パスワードリセット
   resources :password_resets, only: %i[new create edit update ]


### PR DESCRIPTION
Close #290 
### やった事
- [x] ユーザー自身でアカウントの削除が出来るようにコントローラー、ルーティング、ビューに設定を追加
- [x] 投稿詳細画面表示時に、投稿内のアイテム情報にブランドを登録している場合のエラーハンドリング
- [x] 利用規約を確認しようとして(退会の内容を含むため）フッターの表示が隠れていたためUIを修正