### PR TITLE
画像表示パフォーマンス改善_処理の遅い箇所の確認と施策 #170

### DIFF
--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -35,12 +35,15 @@ class PostImageUploader < CarrierWave::Uploader::Base
   #   # do something
   # end
 
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
   # 画像のリサイズと余白の追加
-  process resize_and_pad: [ 1080, 1080, "#ffffff" ]
+  process resize_and_pad: [ 1080, 1080, "#ffffff", "center" ]
+
+  # 表示箇所によってサイズを変えるために、サムネイル生成による表示の最適化を行う
+  # app/views/posts/_post.html.erbのカードで「post.post_image.thumb.url」で呼び出す
+  # Create different versions of your uploaded files:
+  version :thumb do
+    process resize_to_fit: [ 500, 500 ]
+  end
 
 
   # Add an allowlist of extensions which are allowed to be uploaded.
@@ -68,24 +71,5 @@ class PostImageUploader < CarrierWave::Uploader::Base
   # 拡張子を.webpで保存
   def filename
     super.chomp(File.extname(super)) + ".webp"
-  end
-
-  private
-
-  # 画像のリサイズと余白の追加を行うメソッド
-  def resize_and_pad(width, height, background = "#ffffff")
-    manipulate! do |img|
-      # 画像を指定サイズにリサイズ（アスペクト比を保つ）
-      img.resize "#{width}x#{height}"
-
-      # 指定サイズに合わせて余白を追加
-      img.combine_options do |cmd|
-        cmd.background background
-        cmd.gravity "center"
-        cmd.extent "#{width}x#{height}"
-      end
-
-      img
-    end
   end
 end

--- a/app/uploaders/product_image_uploader.rb
+++ b/app/uploaders/product_image_uploader.rb
@@ -35,12 +35,15 @@ class ProductImageUploader < CarrierWave::Uploader::Base
   #   # do something
   # end
 
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
   # 画像のリサイズと余白の追加
-  process resize_and_pad: [ 1080, 1080, "#ffffff" ]
+  process resize_and_pad: [ 1080, 1080, "#ffffff", "center" ]
+
+  # 表示箇所によってサイズを変えるために、サムネイル生成による表示の最適化を行う
+  # app/views/brand_admin/products/_product.html.erbのカードで「post.post_image.thumb.url」で呼び出す
+  # Create different versions of your uploaded files:
+  version :thumb do
+    process resize_to_fit: [ 500, 500 ]
+  end
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
@@ -69,24 +72,5 @@ class ProductImageUploader < CarrierWave::Uploader::Base
   # 拡張子を.webpで保存
   def filename
     super.chomp(File.extname(super)) + ".webp" if original_filename.present?
-  end
-
-  private
-
-  # 画像のリサイズと余白の追加を行うメソッド
-  def resize_and_pad(width, height, background = "#ffffff")
-    manipulate! do |img|
-      # 画像を指定サイズにリサイズ（アスペクト比を保つ）
-      img.resize "#{width}x#{height}"
-
-      # 指定サイズに合わせて余白を追加
-      img.combine_options do |cmd|
-        cmd.background background
-        cmd.gravity "center"
-        cmd.extent "#{width}x#{height}"
-      end
-
-      img
-    end
   end
 end

--- a/app/views/brand_admin/posts/_post.html.erb
+++ b/app/views/brand_admin/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <div class="card rounded-xl bg-base-100 shadow-md aspect-[1/1]">
   <div class="card-image" style="height: 75%;">
-    <%= link_to image_tag(post.post_image.url, class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
+    <%= link_to image_tag(post.post_image.thumb.url, class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
   </div>
 
   <div class="flex justify-between items-center mx-3 py-1 border-b">

--- a/app/views/brand_admin/products/_product.html.erb
+++ b/app/views/brand_admin/products/_product.html.erb
@@ -1,6 +1,6 @@
 <div class="card rounded-xl bg-base-100 shadow-md aspect-[1/1]">
   <div class="card-image" style="height: 84%;">
-    <%= link_to image_tag(product.product_image.url, class: 'rounded-t-xl w-full h-full object-cover'), brand_admin_product_path(product) %>
+    <%= link_to image_tag(product.product_image.thumb.url, class: 'rounded-t-xl w-full h-full object-cover'), brand_admin_product_path(product) %>
   </div>
   <div class="flex items-center justify-between" style="height: 16%">
     <ul class="list-inline">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <div class="card rounded-xl bg-base-100 shadow-md aspect-[1/1]">
   <div class="card-image" style="height: 75%;">
-    <%= link_to image_tag(post.post_image.url, class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
+    <%= link_to image_tag(post.post_image.thumb.url, class: 'rounded-t-xl w-full h-full object-cover'), post_path(post) %>
   </div>
 
   <div class="flex justify-between items-center mx-3 py-1 border-b">


### PR DESCRIPTION
Close #170 
### やった事

- [x] 投稿登録後の一覧画面への遷移に時間がかかる原因の検証(デベロッパーツールとPageSpeed Insightsで検証)
- [x] 表示箇所によって画像サイズを変えるため、サムネイル生成による表示の最適化を行った
- [x] サムネイル生成に伴って、ビューでの呼び出しを修正
- [x] 投稿の登録、一覧表示と同じ仕組みを利用している商品登録も一緒に修正

### 上記の施策を行った理由
デベロッパーツールとPageSpeed Insightsの結果から、
どちらもLCPの時間が長く、パスは一覧に表示しているカードの画像部分を指していることが分かった。
**一番の原因は一覧画面のカードで表示している画像サイズが大きすぎる事だと仮定**し、
表示箇所によって画像サイズを最適化できるようにサムネイルの生成を行うこととした。
![image](https://github.com/user-attachments/assets/baa84141-bf55-4b7a-9e90-dfa92e662489)
![image](https://github.com/user-attachments/assets/46ca11c5-d290-4d02-8028-ad85498e34c7)
