### PR TITLE
画像表示パフォーマンス改善_処理の遅い箇所の確認と施策 #170

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,11 +27,11 @@ class PostsController < ApplicationController
 
     if @post.save
       if @post.draft?
-        redirect_to posts_path, success: "下書きに保存しました"
+        redirect_to post_path(@post), success: "下書きに保存しました"
       elsif @post.unpublished?
-        redirect_to posts_path, success: "非公開の投稿に保存しました"
+        redirect_to post_path(@post), success: "非公開の投稿に保存しました"
       else
-        redirect_to posts_path, success: "投稿を公開しました"
+        redirect_to post_path(@post), success: "投稿を公開しました"
       end
     else
       flash.now[:danger] = "投稿の作成に失敗しました"

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: post, data: { turbo: false } do |f| %>
+<%= form_with model: post do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
 
   <!-- 投稿画像 -->


### PR DESCRIPTION
### やった事

- [x] フォームをTurboを有効にして送信するようにする
- [x] 登録完了後の遷移先を一覧から投稿詳細ページに修正

### 上記を実施した理由

- Rails7では、Turbo Driveが標準で有効になっているが、
フラッシュを自動で消すスクリプトを動かすために、フォームのTurbo送信を無効化していた為、有効にすることで遅延が解消されるか試みる。
- ページの遷移先を複数画像を読み込む一覧画面ではなく、1枚だけ読み込む詳細画面にすることで遅延が解消できるか試みるため。

### マージ後に行う事
- [ ] デプロイし、処理時間を確認する