### PR TITLE
画像表示パフォーマンス改善_処理の遅い箇所の確認と施策 #170

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,11 +27,11 @@ class PostsController < ApplicationController
 
     if @post.save
       if @post.draft?
-        redirect_to post_path(@post), success: "下書きに保存しました"
+        flash[:success] = "下書きに保存しました"
       elsif @post.unpublished?
-        redirect_to post_path(@post), success: "非公開の投稿に保存しました"
+        flash[:success] = "非公開の投稿に保存しました"
       else
-        redirect_to post_path(@post), success: "投稿を公開しました"
+        flash[:success] = "投稿を公開しました"
       end
     else
       flash.now[:danger] = "投稿の作成に失敗しました"

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,11 +27,11 @@ class PostsController < ApplicationController
 
     if @post.save
       if @post.draft?
-        flash[:success] = "下書きに保存しました"
+        flash.now[:success] = "下書きに保存しました"
       elsif @post.unpublished?
-        flash[:success] = "非公開の投稿に保存しました"
+        flash.now[:success] = "非公開の投稿に保存しました"
       else
-        flash[:success] = "投稿を公開しました"
+        flash.now[:success] = "投稿を公開しました"
       end
     else
       flash.now[:danger] = "投稿の作成に失敗しました"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -84,7 +84,22 @@
 
   <!-- フラッシュメッセージを自動で消す処理 -->
   <script>
+    // ページがロードされた時用
     document.addEventListener('turbo:load', function() {
+      const flashMessage = document.getElementById('flash-message');
+      if (flashMessage) {
+        setTimeout(() => {
+          flashMessage.classList.add('fade-out'); // CSSで指定したフェードアウトクラスを追加
+          setTimeout(() => {
+            flashMessage.style.display = 'none'; // 完全に非表示にする
+          }, 500); // 0.5秒後に非表示にする
+        }, 3000); // 3000ミリ秒（3秒）後にフェードアウト開始
+      }
+    });
+  </script>
+  <script>
+    // Turbo Streamによって部分更新された時用
+    document.addEventListener('turbo:render', function() {
       const flashMessage = document.getElementById('flash-message');
       if (flashMessage) {
         setTimeout(() => {

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: post do |f| %>
+<%= form_with model: post, id: "post-form" do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
 
   <!-- 投稿画像 -->

--- a/app/views/posts/_form_result.html.erb
+++ b/app/views/posts/_form_result.html.erb
@@ -1,0 +1,177 @@
+<% content_for(:title, t('.title')) %>
+<div class="container pt-16">
+  <div class="w-full p-4 md:px-0 md:py-2 md:w-1/2 mx-auto border-b">
+    <ul class="list-inline flex items-center">
+      <li class="mr-2 flex-shrink-0"><%= image_tag @post.user.avatar_url, class: "w-10 h-10 rounded-full border" %></li>
+      <li class="break-all"><%= @post.user.name %></li>
+    </ul>
+  </div>
+</div>
+
+<div class="relative w-full md:w-1/2 mx-auto">
+  <%= image_tag(@post.post_image.url, class: 'block w-full h-auto object-contain') %>
+</div>
+
+<!-- 日付・お気に入りボタン -->
+<div class="flex justify-between items-center w-full md:w-1/2 mx-auto px-4 pt-4 pb-4 md:px-0 md:pt-4 md:pb-4 text-sm">
+  <p class="mr-2">
+    <%= @post.created_at.in_time_zone('Asia/Tokyo').strftime("%Y.%-m.%-d") %>
+  </p>
+
+  <!-- ログインしていない場合は、アイコンを表示しない -->
+  <% if current_user %>
+    <div class="flex">
+      <!-- 自分以外の投稿ならお気に入りアイコンを表示 -->
+      <% unless current_user.own?(@post) %>
+        <%= render 'favorite_buttons', { post: @post } %>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+<!-- 投稿本文 -->
+<div class="body-content">
+  <div class="break-words w-full px-4 pt-4 pb-4 md:px-0 md:pt-4 md:pb-4 md:w-1/2 mx-auto border-t text-sm">
+    <p><%= simple_format(h(@post.body)) %></p>
+  </div>
+</div>
+
+<!-- アイテム情報 -->
+<div class="flex items-center w-full px-4 pt-4 md:px-0 md:pt-4 md:w-1/2 mx-auto border-t">
+<h3 class="font-semibold" >アイテム情報</h3>
+</div>
+
+<!-- ブランド -->
+<div class="brand">
+  <div class="flex w-full px-4 pt-4 md:px-0 md:pt-4 md:w-1/2 mx-auto">
+    <div class="w-1/5 text-xs">
+      <p>ブランド /</p>
+    </div>
+    <div class="w-4/5 text-sm break-all">
+      <% if @brand_admin %>
+        <p><%= @brand_admin.name %></p>
+      <% else %>
+        <p>未登録</p>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<!-- 商品情報 -->
+<div class="product">
+  <div class="flex w-full px-4 pt-4 md:px-0 md:pt-4 md:w-1/2 mx-auto">
+    <div class="w-1/5 text-xs">
+      <p>商品名　 /</p>
+    </div>
+    <div class="w-4/5 text-sm break-all">
+      <% if @product_name %>
+        <p><%= @product_name %></p>
+      <% else %>
+        <p>未登録</p>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<!-- 使用年数 -->
+<div class="used_year">
+  <div class="flex w-full px-4 pt-4 md:px-0 md:pt-4 md:w-1/2 mx-auto">
+    <div class="w-1/5 text-xs">
+      <p>使用年数 /</p>
+    </div>
+    <div class="w-4/5 text-sm">
+      <% if @post.used_year.present? %>
+        <p><%= @post.used_year %></p>
+      <% else %>
+        <p>未登録</p>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<!-- カラー -->
+<div class="color">
+  <div class="flex w-full px-4 pt-4 pb-10 md:px-0 md:pt-4 md:pb-10 md:w-1/2 mx-auto">
+    <div class="w-1/5 text-xs">
+      <p>カラー　 /</p>
+    </div>
+    <div class="w-4/5 text-sm">
+      <% if @post.color.present? %>
+        <p><%= @post.color %></p>
+      <% else %>
+        <p>未登録</p>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+
+<!-- お手入れ情報 -->
+<div class="flex items-center w-full px-4 pt-4 md:px-0 md:pt-4 md:w-1/2 mx-auto border-t">
+<h3 class="font-semibold" >お手入れ情報</h3>
+</div>
+
+<!-- 頻度 -->
+<div class="care_frequency">
+  <div class="flex w-full px-4 pt-4 md:px-0 md:pt-4 md:w-1/2 mx-auto">
+    <div class="w-1/5 text-xs">
+      <p>ケア頻度 /</p>
+    </div>
+    <div class="w-4/5  text-sm">
+      <% if @post.care_frequency.present? %>
+        <p><%= @post.care_frequency %></p>
+      <% else %>
+        <div class="w-4/5">
+          <p>未登録</p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<!-- ケアアイテム -->
+<div class="care_item">
+  <div class="w-full px-4 pt-4 md:px-0 md:pt-4 md:w-1/2 mx-auto">
+    <div class="text-xs mb-1">
+      <p>ケア用品 /</p>
+    </div>
+    <div class="text-sm">
+      <% if @post.care_item.present? %>
+        <div class="break-words rounded-lg border border-neutral-200 p-2 w-full">
+          <p><%= simple_format(h(@post.care_item)) %></p>
+        </div>
+      <% else %>
+        <div>
+          <p>未登録</p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<!-- ケア方法 -->
+<div class="care_howto">
+  <div class="w-full px-4 pt-4 pb-10 md:px-0 md:pt-4 md:pb-10 md:w-1/2 mx-auto text-sm">
+    <div class="text-xs mb-1">
+      <p>ケア方法 /</p>
+    </div>
+    <div class="text-sm">
+      <% if @post.care_howto.present? %>
+        <div class="break-words rounded-lg border border-neutral-200 p-2 w-full">
+          <p><%= simple_format(h(@post.care_howto))%></p>
+        </div>
+      <% else %>
+        <div>
+          <p>未登録</p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<% if current_user && current_user.own?(@post) %>
+　<div class="w-full p-4 md:px-0 md:py-2 md:w-1/2 mx-auto flex justify-between items-center">
+    <%= link_to "削除", post_path(@post), class: "btn w-1/3 bg-[#e5e5e5] hover:bg-[#a3a3a3]", id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %>
+    <%= link_to "編集", edit_post_path(@post), class: "btn w-1/3 bg-[#E6CCB585] hover:bg-[#fdba74]", id: "button-edit-#{@post.id}" %>
+  </div>
+<% end %>

--- a/app/views/posts/_form_result.html.erb
+++ b/app/views/posts/_form_result.html.erb
@@ -1,5 +1,4 @@
-<% content_for(:title, t('.title')) %>
-<div class="container pt-16">
+<div class="container pt-2">
   <div class="w-full p-4 md:px-0 md:py-2 md:w-1/2 mx-auto border-b">
     <ul class="list-inline flex items-center">
       <li class="mr-2 flex-shrink-0"><%= image_tag @post.user.avatar_url, class: "w-10 h-10 rounded-full border" %></li>

--- a/app/views/posts/create.turbo_stream.erb
+++ b/app/views/posts/create.turbo_stream.erb
@@ -1,0 +1,9 @@
+<% if @post.errors.present? %>
+  <%= turbo_stream.replace "post-form" do %>
+    <%= render 'posts/form', post: @post %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.replace "post-form" do %>
+    <%= render 'posts/form_result', post: Post.new, post: @post %>
+  <% end %>
+<% end %>

--- a/app/views/posts/create.turbo_stream.erb
+++ b/app/views/posts/create.turbo_stream.erb
@@ -4,6 +4,13 @@
   <% end %>
 <% else %>
   <%= turbo_stream.replace "post-form" do %>
+    <div id="flash-message" class="absolute top-16 w-full mx-auto">
+      <%= render 'shared/flash_message' %>
+    </div>
     <%= render 'posts/form_result', post: Post.new, post: @post %>
+    <script>
+     // 画面が一番上にスクロールするように
+      window.scrollTo(0, 0);
+    </script>
   <% end %>
 <% end %>


### PR DESCRIPTION
### やった事

- [x] 投稿作成ボタンを押下後、画面遷移をさせずにTurbo streamを使って、同一画面でパーシャルビューに置換する方法に修正
- [x] 置換後のビューは投稿詳細画面と同様、登録した投稿内容が確認出来る画面とした。
- [x] 画面遷移が行われないため、適切にフラッシュメッセージが表示されるよう調整を行った。

### 上記の実装を実施した経緯
一つ前のプルリクエストで、遷移先を画像表示数の少ない詳細画面へ切り替えたが、遷移の速度が変わらなかった。
また、投稿一覧画面へのリンクを押した時や、画像を表示させている他のページへの遷移時には大幅な時間がかからないことから、画面内の画像サイズや量ではなく、
S3への保存・レスポンスを待ち、ページ全体の読み込みを待つことで処理に時間がかかると推測し、
画面遷移を無くして投稿作成画面の内部を非同期で完了の表示に置換する方法でテストを行うため実装を行った。