### PR TITLE
ブランド検索をnameからid取得に修正、ユーザーのnameカラムのユニーク制約を無くす #305

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,35 +1,39 @@
 class SearchesController < ApplicationController
   skip_before_action :require_login, only: %i[index result]
+  before_action :set_brand_admins, only: %i[index result]
 
   def index
-    @brand_admins = User.brand_admins.order(name: :asc) # スコープでブランド管理者のユーザーを取得
   end
 
   def result
-    brand_name = search_params[:brand_name]
+    brand_admin_id = search_params[:brand_admin_id]
     used_year = search_params[:used_year]
     color = search_params[:color]
 
+    # @brand_adminsから選択されたIDに一致するユーザーを探す
+    selected_brand = @brand_admins.find { |brand| brand.id == brand_admin_id.to_i }
+
     # 選択されたパラメータをインスタンス変数にセット(検索結果に条件を表示させるため)
-    @selected_brand_name = brand_name
+    @selected_brand_name = selected_brand ? selected_brand.name : nil # 見つかったブランドの名前をセットし、見つからない場合にはnilをセット
     @selected_used_year = used_year
     @selected_color = color
-
-    # パラメーターで受け取ったブランド名と一致する、brand_admin権限を持つユーザーを探す。
-    brand_admin = User.brand_admins.find_by(name: brand_name)
 
     # 投稿の初期値を全て取得
     @posts = Post.includes(:user).order(created_at: :desc)
 
-  # 条件に基づいて絞り込みを行う
-  @posts = @posts.brand_post_search(brand_admin.id) if brand_admin.present?
-  @posts = @posts.used_year_post_search(used_year) if used_year.present?
-  @posts = @posts.color_post_search(color) if color.present?
+    # 条件に基づいて絞り込みを行う
+    @posts = @posts.brand_post_search(brand_admin_id) if brand_admin_id.present?
+    @posts = @posts.used_year_post_search(used_year) if used_year.present?
+    @posts = @posts.color_post_search(color) if color.present?
   end
 
   private
 
   def search_params
-    params.permit(:brand_name, :used_year, :color)
+    params.permit(:brand_admin_id, :used_year, :color)
+  end
+
+  def set_brand_admins
+    @brand_admins = User.brand_admins.order(name: :asc) # スコープでブランド管理者のユーザーを取得
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   mount_uploader :avatar, AvatarUploader
 
-  validates :name, presence: true, length: { maximum: 50 }, uniqueness: { message: "：このユーザー名は使用できません。別の名前をご入力ください。" }
+  validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, uniqueness: { message: "：このメールアドレスは使用できません。別のメールアドレスをご入力ください。" }
   validates :password, length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -99,7 +99,7 @@
               <td class="flex items-center cursor-pointer" onclick="this.querySelector('form').submit();">
                 <%= image_tag(brand.avatar_url, alt: "#{brand.name}のアバター", class: "w-10 h-10 rounded-full border mr-2") %>
                 <%= form_with url: result_searches_path, method: :post, data: { turbo: false } do |f| %>
-                  <%= f.hidden_field :brand_name, value: brand.name %>
+                  <%= f.hidden_field :brand_admin_id, value: brand.id %>
                   <%= f.submit brand.name, class: "block w-full text-left whitespace-normal break-all" %>
                 <% end %>
               </td>
@@ -199,7 +199,7 @@
         <!-- ブランド選択 -->
         <div class="mx-auto w-11/12 md:w-1/2 pt-3">
           <%= f.label :brand_name, 'ブランド', class: 'label text-xs font-medium' %>
-          <%= f.select :brand_name, @brand_admins.collect { |brand_admin| [brand_admin.name, brand_admin.name] }, { include_blank: "未選択" }, class: 'select rounded-lg border border-neutral-200 w-full' %>
+          <%= f.select :brand_admin_id, @brand_admins.collect { |brand_admin| [brand_admin.name, brand_admin.id] }, { include_blank: "未選択" }, class: 'select rounded-lg border border-neutral-200 w-full' %>
         </div>
 
         <!-- 使用年数選択 -->

--- a/db/migrate/20241026112219_add_unique_index_to_users_name.rb
+++ b/db/migrate/20241026112219_add_unique_index_to_users_name.rb
@@ -1,5 +1,0 @@
-class AddUniqueIndexToUsersName < ActiveRecord::Migration[7.2]
-  def change
-    add_index :users, :name, unique: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,7 +77,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_20_143213) do
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,13 +10,6 @@ RSpec.describe User, type: :model do
 
     # ユニークバリデーションのチェック
 
-    it '同じ名前があると無効になること' do
-      user1 = create(:user)
-      user2 = build(:user, name: user1.name)
-      expect(user2).to be_invalid
-      expect(user2.errors[:name]).to include("：このユーザー名は使用できません。別の名前をご入力ください。")
-    end
-
     it '同じメールアドレスがあると無効になること' do
       user1 = create(:user)
       user2 = build(:user, email: user1.email)


### PR DESCRIPTION
Close #305 
### やった事
- [x] ブランド検索をnameからid取得に修正
- [x] ユーザーのnameカラムのユニーク制約を無くす（マイグレーションのロールバックと削除）
- [x] ユーザーモデルのバリデーションも外す
- [x] 不要になったテストコードの削除

### 上記の実施理由
#197 の実装でブランドidがURLに表示される問題の解決方法として、ブランド名を検索時に取得する方法を取るためユニーク制約を付けていたが、
#201 でPOSTリクエストへ修正したことでURLに表示されなくなった。
ブランドのid取得に変更することにより、usersテーブルのnameのユニーク制約が不要となり、
新規登録やGoogleログインによる新規ユーザーの間口を広げられるため、修正を行った。