### PR TITLE
投稿ステータスが下書きかつbodyが空の時の設定 #311

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -78,7 +78,16 @@ class PostsController < ApplicationController
         :draft
       end
 
-    if @post.update(post_params)
+    # ステータスがdraftで、bodyが空の場合は「未登録」の文字を設定
+    if @post.draft? && post_params[:body].blank?
+      @post.body = "メッセージ未登録"
+    else
+      # ステータスがdraftではない、または空でない場合、# 入力されている値を使う
+      @post.body = post_params[:body]
+    end
+
+    # post_paramsにある他の情報に加えてbodyに現在の内容を追加する
+    if @post.update(post_params.merge(body: @post.body))
       if @post.draft?
         redirect_to post_path(@post), success: "下書きに保存しました"
       elsif @post.unpublished?

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,6 +25,11 @@ class PostsController < ApplicationController
         :published
       end
 
+    # ステータスがdraftで、bodyが空の場合は「未登録」の文字を設定
+    if @post.draft? && @post.body.blank?
+      @post.body = "メッセージ未登録"
+    end
+
     if @post.save
       if @post.draft?
         redirect_to mypage_path, success: "下書きに保存しました"


### PR DESCRIPTION
Close #311 
### やった事
- [x] 投稿を下書きで登録する時にメッセージが空でも(＝ユーザーが入力していなくても)保存できるようにする

app/models/post.rb　に以下のように記述をすることで、
ステータスがdraftの場合は投稿のbodyが空でもバリデーションに引っ掛からずに保存が出来るようになった。
しかし、文字の最大数のバリデーションも効かなくなった。
```
 validates :body, presence: true, unless: :draft?, length: { maximum: 2000 }

  def draft?
    status == 'draft'
  end
```
そのため、**コントローラー側で設定した文字が入るようにし、既存のバリデーションを活かしたまま、ユーザーの入力が空だった場合に補助する仕様で対処**した。