### PR TITLE
ローディングアニメーション（処理が重い箇所） #315

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,6 +10,9 @@ application.register("hello", HelloController)
 import ImagePreviewController from "./image_preview_controller"
 application.register("image-preview", ImagePreviewController)
 
+import LoadingController from "./loading_controller"
+application.register("loading", LoadingController)
+
 import ProductSelectController from "./product_select_controller"
 application.register("product-select", ProductSelectController)
 

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="loading"
+export default class extends Controller {
+  static targets = ["button", "modal"];
+
+  connect() {
+    this.modalTarget.classList.add("hidden"); // 初期状態では非表示
+  }
+
+  showLoading(event) {
+    event.preventDefault(); // 通常の送信を防ぐ
+    this.buttonTarget.disabled = true; // ボタンを無効化
+    this.modalTarget.classList.remove("hidden"); // モーダルを表示
+
+    // 少し遅延させてフォームを送信
+    setTimeout(() => {
+      this.buttonTarget.form.submit(); // フォームを送信
+    }, 100); // 100ミリ秒遅延
+  }
+}

--- a/app/views/brand_admin/products/_form.html.erb
+++ b/app/views/brand_admin/products/_form.html.erb
@@ -20,7 +20,12 @@
   <%= f.label :product_name, class: "label w-5/6 md:w-1/2 mx-auto pt-4 font-medium" %>
   <%= f.text_field :product_name, placeholder: "商品名をご入力ください", class: "input input-bordered form-control w-5/6 md:w-1/2 mx-auto h-10", required: true %>
 
-  <div class='mx-auto w-5/6 md:w-1/2'>
-    <%= f.submit "登録", class: "btn mt-8 w-full mt-6 mb-5 mx-auto h-10 bg-[#E6CCB585] hover:bg-[#fdba74] text-yellow-900", id: "submit-button" %>
+  <div class='mx-auto w-5/6 md:w-1/2', data-controller="loading">
+    <%= f.submit "登録", class: "btn mt-8 w-full mt-6 mb-5 mx-auto h-10 bg-[#E6CCB585] hover:bg-[#fdba74] text-yellow-900", data: { action: "click->loading#showLoading", loading_target: "button" } %>
+
+    <!-- ローディングモーダル -->
+    <div data-loading-target="modal" class="hidden fixed inset-0 flex items-center justify-center bg-darkbrown bg-opacity-50 z-50">
+      <%= render 'shared/loading'%>
+    </div>
   </div>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -140,18 +140,25 @@
   </details>
 
   <!-- 投稿関連のボタン -->
-  <div class="mx-auto w-5/6 md:w-1/2 mt-20 flex justify-between items-center">
-    <div class='mx-auto w-5/6 md:w-1/2 mr-1'>
-      <%= f.submit "下書きに保存", name: "draft", class: "btn w-full mx-auto h-10 bg-[#d4d4d4] hover:bg-[#fdba74]", id: "submit-button-draft"%>
+  <div data-controller="loading">
+    <div class="mx-auto w-5/6 md:w-1/2 mt-20 flex justify-between items-center">
+      <div class='mx-auto w-5/6 md:w-1/2 mr-1'>
+        <%= f.submit "下書きに保存", name: "draft", class: "btn w-full mx-auto h-10 bg-[#d4d4d4] hover:bg-[#fdba74]", data: { action: "click->loading#showLoading", loading_target: "button" } %>
+      </div>
+
+      <div class='mx-auto w-5/6 md:w-1/2 ml-1'>
+        <%= f.submit "非公開で投稿", name: "unpublished", class: "btn w-full mx-auto h-10 bg-[#d4d4d4] hover:bg-[#fdba74]", data: { action: "click->loading#showLoading", loading_target: "button" }%>
+      </div>
     </div>
 
-    <div class='mx-auto w-5/6 md:w-1/2 ml-1'>
-      <%= f.submit "非公開で投稿", name: "unpublished", class: "btn w-full mx-auto h-10 bg-[#d4d4d4] hover:bg-[#fdba74]", id: "submit-button-unpublished"%>
+    <div class='mx-auto w-5/6 md:w-1/2'>
+      <%= f.submit "投稿(公開)", name: "published", class: "btn mt-10 w-full mb-5 mx-auto h-10 bg-[#E6CCB585] hover:bg-[#fdba74]", data: { action: "click->loading#showLoading", loading_target: "button" } %>
     </div>
-  </div>
 
-  <div class='mx-auto w-5/6 md:w-1/2'>
-    <%= f.submit "投稿(公開)", name: "published", class: "btn mt-10 w-full mb-5 mx-auto h-10 bg-[#E6CCB585] hover:bg-[#fdba74]", id: "submit-button-published"%>
+    <!-- ローディングモーダル -->
+    <div data-loading-target="modal" class="hidden fixed inset-0 flex items-center justify-center bg-darkbrown bg-opacity-50 z-50">
+      <%= render 'shared/loading'%>
+    </div>
   </div>
 
 <% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -48,8 +48,13 @@
           </div>
       <% end %>
 
-      <div>
-        <%= f.submit "登録", class: "btn mt-8 mb-5 w-full mx-auto h-10 bg-[#E6CCB585] text-darkbrown", id: "submit_button" %>
+      <div data-controller="loading">
+        <%= f.submit "登録", class: "btn mt-8 mb-5 w-full mx-auto h-10 bg-[#E6CCB585] text-darkbrown", data: { action: "click->loading#showLoading", loading_target: "button" } %>
+        
+        <!-- ローディングモーダル -->
+        <div data-loading-target="modal" class="hidden fixed inset-0 flex items-center justify-center bg-darkbrown bg-opacity-50 z-50">
+          <%= render 'shared/loading'%>
+        </div>
       </div>
 
     </div>

--- a/app/views/shared/_loading.html.erb
+++ b/app/views/shared/_loading.html.erb
@@ -1,0 +1,6 @@
+<div class="bg-white p-6 rounded shadow-lg text-center">
+    <div class="flex justify-center">
+        <div class="animate-spin h-8 w-8 border-4 border-beige rounded-full border-t-transparent"></div>
+    </div>
+    <div class="text-sm mt-4">送信中...</div>
+</div>


### PR DESCRIPTION
Close #315 
### やった事
画像を含むフォームなどの送信ボタンを押したときにローディングアニメーションが表示されるようにした。

- [x] Stimulsコントローラーの作成
- [x] 投稿作成ボタンにイベント発火、モーダル表示のターゲットを追加
- [x] アニメーションパーシャルを用意
- [x] モーダルでアニメーションを読み込ませる
  
アニメーションが必要な箇所

- [x] 投稿作成画面
- [x] プロフィールの編集画面(アバターの画像送信があるため)
- [x] ブランド用の商品登録ボタン