### PR TITLE
投稿ステータスが効かなくなった為、その対処 #315

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -70,3 +70,31 @@
   opacity: 0; /* 要素の透明度を設定するプロパティ。0は完全に透明、つまり見えない状態 */
   transition: opacity 0.5s ease; /* アニメーションの設定。opacity（透明度）が変わるときの早さを指定。0.5秒でフェードアウト */
 }
+
+/* 投稿フォームのラジオボタン */
+.custom-radio {
+  appearance: none; /* デフォルトのスタイルを無効化 */
+  width: 1.25rem; /* h-5ぐらい＝1.25remを指定 */
+  height: 1.25rem; /* h-5ぐらい＝1.25remを指定 */
+  border: 1px solid #847366; /* ボーダー色の設定 */
+  border-radius: 50%; /* 円形にする */
+  outline: none; /* フォーカス時のアウトラインを無効化 */
+  cursor: pointer; /* カーソルをポインターに */
+  position: relative; /* 子要素の位置を相対的に設定 */
+}
+
+.custom-radio:checked {
+  border-color: #847366; /* チェック時のボーダー色 */
+}
+
+.custom-radio:checked::before {
+  content: ''; /* 擬似要素のコンテンツを空にする */
+  position: absolute; /* 親要素に対して絶対配置 */
+  top: 50%; /* 親要素の中央に配置 */
+  left: 50%; /* 親要素の中央に配置 */
+  transform: translate(-50%, -50%); /* 中央揃え */
+  width: 0.75rem; /* チェックの円のサイズ */
+  height: 0.75rem; /* チェックの円のサイズ */
+  border-radius: 50%; /* 円形にする */
+  background-color: #5f534a; /* チェックマークの色 */
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,16 +15,6 @@ class PostsController < ApplicationController
     @post = current_user.posts.build(post_params)
     @post.brand_admin_id = params[:post][:brand_admin_id].presence # nilまたは空文字の場合は自動的にnilになる
 
-    # params[:draft]があれば下書き、params[:unpublished]があれば非公開、どちらもなければ公開投稿
-    @post.status =
-      if params[:draft].present?
-        :draft
-      elsif params[:unpublished].present?
-        :unpublished
-      else
-        :published
-      end
-
     # ステータスがdraftで、bodyが空の場合は「未登録」の文字を設定
     if @post.draft? && @post.body.blank?
       @post.body = "メッセージ未登録"
@@ -67,16 +57,6 @@ class PostsController < ApplicationController
 
   def update
     @post = current_user.posts.find(params[:id])
-
-    # params[:published]があれば公開、params[:unpublished]があれば非公開、どちらもなければ下書き
-    @post.status =
-      if params[:published].present?
-        :published
-      elsif params[:unpublished].present?
-        :unpublished
-      else
-        :draft
-      end
 
     # ステータスがdraftで、bodyが空の場合は「未登録」の文字を設定
     if @post.draft? && post_params[:body].blank?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,7 +12,7 @@ class Post < ApplicationRecord
   has_many :favorites, dependent: :destroy
 
   # 投稿のステータス（下書き,公開,非公開）
-  enum status: { draft: 0, published: 1, unpublished: 2 }
+  enum status: [ :draft, :published, :unpublished ]
 
   # ステータスごとに投稿を取得するスコープ
   scope :published, -> { where(status: :published) }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -139,20 +139,31 @@
       </div>
   </details>
 
-  <!-- 投稿関連のボタン -->
-  <div data-controller="loading">
-    <div class="mx-auto w-5/6 md:w-1/2 mt-20 flex justify-between items-center">
-      <div class='mx-auto w-5/6 md:w-1/2 mr-1'>
-        <%= f.submit "下書きに保存", name: "draft", class: "btn w-full mx-auto h-10 bg-[#d4d4d4] hover:bg-[#fdba74]", data: { action: "click->loading#showLoading", loading_target: "button" } %>
+  <!-- ステータス選択ラジオボタン -->
+  <div class="mx-auto w-5/6 md:w-1/2 mt-10">
+    <div class="text-start font-medium mb-1">
+      <p>ステータスを選択</p>
+    </div>
+    <div class="flex justify-between items-center py-3 bg-white rounded-lg">
+      <div class="flex flex-col items-center flex-1">
+        <%= f.radio_button :status, :draft, class: "custom-radio" %>
+        <%= f.label :status_draft, "下書き", class: "mt-1 text-sm cursor-pointer" %>
       </div>
-
-      <div class='mx-auto w-5/6 md:w-1/2 ml-1'>
-        <%= f.submit "非公開で投稿", name: "unpublished", class: "btn w-full mx-auto h-10 bg-[#d4d4d4] hover:bg-[#fdba74]", data: { action: "click->loading#showLoading", loading_target: "button" }%>
+      <div class="flex flex-col items-center flex-1">
+        <%= f.radio_button :status, :unpublished, class: "custom-radio" %>
+        <%= f.label :status_unpublished, "非公開", class: "mt-1 text-sm cursor-pointer" %>
+      </div>
+      <div class="flex flex-col items-center flex-1">
+        <%= f.radio_button :status, :published, class: "custom-radio" %>
+        <%= f.label :status_published, "公開", class: "mt-1 text-sm cursor-pointer" %>
       </div>
     </div>
+  </div>
 
-    <div class='mx-auto w-5/6 md:w-1/2'>
-      <%= f.submit "投稿(公開)", name: "published", class: "btn mt-10 w-full mb-5 mx-auto h-10 bg-[#E6CCB585] hover:bg-[#fdba74]", data: { action: "click->loading#showLoading", loading_target: "button" } %>
+  <!-- 登録ボタンを押すとローディングアニメーション -->
+  <div data-controller="loading">
+    <div class='mx-auto w-5/6 md:w-1/2 mt-10'>
+      <%= f.submit "登録", class: "btn mt-10 w-full mb-5 mx-auto h-10 bg-[#E6CCB585] hover:bg-[#fdba74]", data: { action: "click->loading#showLoading", loading_target: "button" } %>
     </div>
 
     <!-- ローディングモーダル -->


### PR DESCRIPTION
### やった事

- [x] 警告が出ないようにenumを設定し直す(`Defining enums with keyword arguments is deprecated`の対処)
- [x] フォームのボタンを登録ボタンとステータス選択と分けて表示するように変更。
- [x] ラジオボタンの装飾をCSSで設定
- [x] コントローラーでステータスを操作していた部分を削除(create、updateアクション内)

### 上記を実施した経緯
ローディングアニメーションを追加したことにより、投稿ステータスが「公開」に置き換わってしまう事象が発生したため、適切にパラメーターを受け取り、「下書き」「非公開」「公開」ステータスが機能するように修正を行った。