### PR TITLE
(バグ対応)投稿フォームに画像の推奨サイズを追加 #341

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -4,6 +4,7 @@
   <!-- 投稿画像 -->
   <div data-controller="image-preview" data-image-preview-width="250" data-image-preview-height="250">
     <%= f.label :post_image, '画像選択', class: 'label w-5/6 md:w-1/2 mx-auto pt-5 font-medium'%>
+    <p class="text-start text-sm w-5/6 md:w-1/2 mx-auto">（推奨サイズ：1080×1080pxの正方形）</p>
     <%= f.file_field :post_image, class: 'file-input file-input-bordered form-control w-5/6 md:w-1/2 mx-auto text-sm', accept: 'image/*', data: { "image-preview-target": "input", action: "change->image-preview#previewImage"} %>
     <%= f.hidden_field :post_image_cache %>
 


### PR DESCRIPTION
close #341 
### やった事
画像登録時に以下のバグ報告があったため、事前のトリミングを促すために推奨サイズを記載して様子を見てみる。
　
**バグ報告内容**
（どちらもAndroidからの投稿）
・余白の色がピンクになった→他の画像にしたら普通に白い余白になった
・「投稿画像Translation missing :ja errors.messages.processing_error」の表記が出た→処理中に何かエラーが起こった際の日本語翻訳が無いというエラー。



**確認結果**
どちらもログを確認してもエラーの痕跡が無い＆
バグが出た際の同じ画像をもらい、自分のPCとスマホ(iphone)でテストしたが問題なく投稿が出来たため、原因が分からず、
ひとまず推奨サイズを記載することで事前のトリミングを促す対応とした。
