### PR TITLE
【エラー報告対応】アバター画像の推奨サイズの説明を追加 #351

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -16,6 +16,7 @@
         </div>
 
         <%= f.label :avatar, class: "label w-full mx-auto text-sm" %>
+        <p class="text-start text-sm">（推奨サイズ：320×320px）</p>
         <%= f.file_field :avatar, class: 'file-input file-input-bordered form-control w-full mx-auto', accept: 'image/*' %>
         <%= f.hidden_field :avatar_cache %>
       </div>


### PR DESCRIPTION
close #351 
### やった事
プロフィール編集画面の画像選択部分に推奨サイズを追加

#### 経緯
画像登録時に「Translation missing :ja errors.messages.processing_error」エラーがあったと報告があった。
このエラー自体は翻訳が無い事に対してだが、処理中にエラーが発生する事が原因と考えている。
ログに痕跡が残っておらず、根本的な原因の調査には時間が掛かると判断し、
容量が小さい(150KB程度)画像は保存が可能だったとの報告も同時にあったため、まずはユーザーにリサイズを促して一次対処とした。